### PR TITLE
Add image-uri MCP capability support

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -394,6 +394,17 @@ impl Session {
             .await
     }
 
+    pub async fn read_resource(
+        &self,
+        server: &str,
+        uri: String,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<mcp_types::ReadResourceResult> {
+        self.mcp_connection_manager
+            .read_resource(server, uri, timeout)
+            .await
+    }
+
     pub fn abort(&self) {
         info!("Aborting existing session");
         let mut state = self.state.lock().unwrap();

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1,6 +1,11 @@
 use std::time::Duration;
 
-use tracing::error;
+use tracing::{error, warn};
+
+use mcp_types::{
+    CallToolResult, CallToolResultContent, EmbeddedResourceResource, ImageContent,
+    ReadResourceResultContents,
+};
 
 use crate::codex::Session;
 use crate::models::FunctionCallOutputPayload;
@@ -9,6 +14,9 @@ use crate::protocol::Event;
 use crate::protocol::EventMsg;
 use crate::protocol::McpToolCallBeginEvent;
 use crate::protocol::McpToolCallEndEvent;
+
+/// Timeout when fetching resources referenced by tool call results.
+const READ_RESOURCE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Handles the specified tool call dispatches the appropriate
 /// `McpToolCallBegin` and `McpToolCallEnd` events to the `Session`.
@@ -54,14 +62,70 @@ pub(crate) async fn handle_mcp_tool_call(
         .call_tool(&server, &tool_name, arguments_value, timeout)
         .await
         .map_err(|e| format!("tool call error: {e}"));
+
+    let event_result = match &result {
+        Ok(res) => match inline_image_resource(sess, &server, res).await {
+            Some(inlined) => Ok(inlined),
+            None => Ok(res.clone()),
+        },
+        Err(e) => Err(e.clone()),
+    };
+
     let tool_call_end_event = EventMsg::McpToolCallEnd(McpToolCallEndEvent {
         call_id: call_id.clone(),
-        result: result.clone(),
+        result: event_result,
     });
 
     notify_mcp_tool_call_event(sess, sub_id, tool_call_end_event.clone()).await;
 
     ResponseInputItem::McpToolCallOutput { call_id, result }
+}
+
+async fn inline_image_resource(
+    sess: &Session,
+    server: &str,
+    result: &CallToolResult,
+) -> Option<CallToolResult> {
+    let first = result.content.first()?;
+    let CallToolResultContent::EmbeddedResource(embedded) = first else {
+        return None;
+    };
+
+    let EmbeddedResourceResource::BlobResourceContents(blob) = &embedded.resource else {
+        return None;
+    };
+
+    let mime_type = blob
+        .mime_type
+        .as_deref()
+        .filter(|m| m.starts_with("image/"))?;
+
+    let read_res = match sess
+        .read_resource(server, blob.uri.clone(), Some(READ_RESOURCE_TIMEOUT))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("failed to fetch image resource: {e}");
+            return None;
+        }
+    };
+
+    let Some(ReadResourceResultContents::BlobResourceContents(contents)) =
+        read_res.contents.into_iter().next()
+    else {
+        return None;
+    };
+
+    Some(CallToolResult {
+        content: vec![CallToolResultContent::ImageContent(ImageContent {
+            annotations: embedded.annotations.clone(),
+            data: contents.blob,
+            mime_type: contents.mime_type.unwrap_or_else(|| mime_type.to_string()),
+            r#type: "image".to_string(),
+        })],
+        is_error: result.is_error,
+    })
 }
 
 async fn notify_mcp_tool_call_event(sess: &Session, sub_id: &str, event: EventMsg) {

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -349,6 +349,17 @@ impl McpClient {
         self.send_request::<CallToolRequest>(params, timeout).await
     }
 
+    /// Convenience wrapper around `resources/read`.
+    pub async fn read_resource(
+        &self,
+        uri: String,
+        timeout: Option<Duration>,
+    ) -> Result<mcp_types::ReadResourceResult> {
+        let params = mcp_types::ReadResourceRequestParams { uri };
+        self.send_request::<mcp_types::ReadResourceRequest>(params, timeout)
+            .await
+    }
+
     /// Internal helper: route a JSON-RPC *response* object to the pending map.
     async fn dispatch_response(
         resp: JSONRPCResponse,


### PR DESCRIPTION
## Summary
- send Codex UI capability list when initializing MCP clients
- support fetching `image-uri` resources from MCP servers
- expose MCP `read_resource` helper methods
- display images referenced via URI in the TUI

## Testing
- `cargo test --workspace --exclude codex-linux-sandbox --quiet`
